### PR TITLE
Fix: merge array if vmid is undefined

### DIFF
--- a/examples/vuex-async/App.vue
+++ b/examples/vuex-async/App.vue
@@ -10,7 +10,7 @@
   export default {
     metaInfo: {
       meta: [
-        { vmid: 'charset', charset: 'utf-8' }
+        { charset: 'utf-8' }
       ]
     }
   }

--- a/examples/webpack.config.babel.js
+++ b/examples/webpack.config.babel.js
@@ -25,9 +25,9 @@ export default {
 
   module: {
     loaders: [
-      { test: /\.js$/, exclude: /node_modules/, loader: 'babel' },
-      { test: /\.vue$/, loader: 'vue' },
-      { test: /\.json$/, loader: 'json' }
+      { test: /\.js$/, exclude: /node_modules/, loader: 'babel-loader' },
+      { test: /\.vue$/, loader: 'vue-loader' },
+      { test: /\.json$/, loader: 'json-loader' }
     ]
   },
 

--- a/src/shared/getMetaInfo.js
+++ b/src/shared/getMetaInfo.js
@@ -43,7 +43,7 @@ export default function _getMetaInfo (options = {}) {
           let shared = false
           for (let sourceIndex in source) {
             const sourceItem = source[sourceIndex]
-            if (targetItem[tagIDKeyName] === sourceItem[tagIDKeyName]) {
+            if (targetItem[tagIDKeyName] && targetItem[tagIDKeyName] === sourceItem[tagIDKeyName]) {
               shared = true
               break
             }

--- a/test/getMetaInfo.spec.js
+++ b/test/getMetaInfo.spec.js
@@ -1,7 +1,21 @@
 import Vue from 'vue'
 import _getMetaInfo from '../src/shared/getMetaInfo'
+import {
+  VUE_META_KEY_NAME,
+  VUE_META_ATTRIBUTE,
+  VUE_META_SERVER_RENDERED_ATTRIBUTE,
+  VUE_META_TAG_LIST_ID_KEY_NAME
+} from '../src/shared/constants'
 
-const getMetaInfo = _getMetaInfo()
+// set some default options
+const defaultOptions = {
+  keyName: VUE_META_KEY_NAME,
+  attribute: VUE_META_ATTRIBUTE,
+  ssrAttribute: VUE_META_SERVER_RENDERED_ATTRIBUTE,
+  tagIDKeyName: VUE_META_TAG_LIST_ID_KEY_NAME
+}
+
+const getMetaInfo = _getMetaInfo(defaultOptions)
 
 describe('getMetaInfo', () => {
   // const container = document.createElement('div')
@@ -18,6 +32,32 @@ describe('getMetaInfo', () => {
       htmlAttrs: {},
       bodyAttrs: {},
       meta: [],
+      base: [],
+      link: [],
+      style: [],
+      script: [],
+      noscript: []
+    })
+  })
+
+  it('returns metaInfos when used in component', () => {
+    component = new Vue({
+      metaInfo: {
+        title: 'Hello',
+        meta: [
+          { charset: 'utf-8' }
+        ]
+      }
+    })
+    expect(getMetaInfo(component)).to.eql({
+      title: 'Hello',
+      titleChunk: 'Hello',
+      titleTemplate: '%s',
+      htmlAttrs: {},
+      bodyAttrs: {},
+      meta: [
+        { charset: 'utf-8' }
+      ],
       base: [],
       link: [],
       style: [],


### PR DESCRIPTION
See Issue #14 when vmid does not exist.

I also updated the loader to make them more explicit, it seems that with the last update of webpack, we have use the exact module name.