### PR TITLE
Fixed issue with duplicate insertions

### DIFF
--- a/src/client/updaters/updateTags.js
+++ b/src/client/updaters/updateTags.js
@@ -18,19 +18,19 @@ export default function _updateTags (options = {}) {
     const newTags = []
     let indexToDelete
 
-	 if (tags.length > 1) {
-		 // remove duplicates that could have been found by merging tags
-		 // which include a mixin with metaInfo and that mixin is used
-		 // by multiple components on the same page
-		 const found = [];
-		 tags = tags.map(x => {
-			 const k = JSON.stringify(x);
-			 if (found.indexOf(k) < 0) {
-				 found.push(k);
-				 return x;
-			 }
-		 }).filter(x => x);
-	 }
+    if (tags.length > 1) {
+      // remove duplicates that could have been found by merging tags
+      // which include a mixin with metaInfo and that mixin is used
+      // by multiple components on the same page
+      const found = []
+      tags = tags.map(x => {
+        const k = JSON.stringify(x)
+        if (found.indexOf(k) < 0) {
+          found.push(k)
+          return x
+        }
+      }).filter(x => x)
+    }
 
     if (tags && tags.length) {
       tags.forEach((tag) => {

--- a/src/client/updaters/updateTags.js
+++ b/src/client/updaters/updateTags.js
@@ -18,6 +18,20 @@ export default function _updateTags (options = {}) {
     const newTags = []
     let indexToDelete
 
+	 if (tags.length > 1) {
+		 // remove duplicates that could have been found by merging tags
+		 // which include a mixin with metaInfo and that mixin is used
+		 // by multiple components on the same page
+		 const found = [];
+		 tags = tags.map(x => {
+			 const k = JSON.stringify(x);
+			 if (found.indexOf(k) < 0) {
+				 found.push(k);
+				 return x;
+			 }
+		 }).filter(x => x);
+	 }
+
     if (tags && tags.length) {
       tags.forEach((tag) => {
         const newElement = document.createElement(type)


### PR DESCRIPTION
fixed issue where including metaInfo with the same script across multiple components on the same page includes it multiple times. this will de-dupe any of the same tags so that only one is ever inserted