### PR TITLE
Fix undefined defaultOptions

### DIFF
--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -9,17 +9,17 @@ import {
   VUE_META_TAG_LIST_ID_KEY_NAME
 } from './constants'
 
-// automatic install
-if (typeof Vue !== 'undefined') {
-  Vue.use(VueMeta)
-}
-
 // set some default options
 const defaultOptions = {
   keyName: VUE_META_KEY_NAME,
   attribute: VUE_META_ATTRIBUTE,
   ssrAttribute: VUE_META_SERVER_RENDERED_ATTRIBUTE,
   tagIDKeyName: VUE_META_TAG_LIST_ID_KEY_NAME
+}
+
+// automatic install
+if (typeof Vue !== 'undefined') {
+  Vue.use(VueMeta)
 }
 
 /**


### PR DESCRIPTION
Apparently buble doesn't bother to enforce TDZ (babel side of the story - https://github.com/babel/babel/issues/563). As the result `defaultOptions` is undefined when Vue.use(VueMeta) is called (https://jsfiddle.net/u7p5daps/). Simple reordering fixes the problem. 