### PR TITLE
fix bug where old metadata would persist after returning from a child route to the parent

### DIFF
--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -61,6 +61,10 @@ export default function VueMeta (Vue, options = {}) {
     beforeMount () {
       // batch potential DOM updates to prevent extraneous re-rendering
       batchID = batchUpdate(batchID, () => this.$meta().refresh())
+    },
+    destroyed () {
+      // batch potential DOM updates to prevent extraneous re-rendering
+      batchID = batchUpdate(batchID, () => this.$meta().refresh())
     }
   })
 }


### PR DESCRIPTION
This fixes #32 