### PR TITLE
do not trigger a client refresh on the server side

### DIFF
--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -63,7 +63,7 @@ export default function VueMeta (Vue, options = {}) {
       batchID = batchUpdate(batchID, () => this.$meta().refresh())
     },
     destroyed () {
-      //do not trigger refresh on the server side
+      // do not trigger refresh on the server side
       if (this.$isServer) return
       // re-render meta data when returning from a child component to parent
       batchID = batchUpdate(batchID, () => this.$meta().refresh())

--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -63,7 +63,9 @@ export default function VueMeta (Vue, options = {}) {
       batchID = batchUpdate(batchID, () => this.$meta().refresh())
     },
     destroyed () {
-      // batch potential DOM updates to prevent extraneous re-rendering
+      //do not trigger refresh on the server side
+      if (this.$isServer) return
+      // re-render meta data when returning from a child component to parent
       batchID = batchUpdate(batchID, () => this.$meta().refresh())
     }
   })


### PR DESCRIPTION
This PR fixes a server crash when using this plugin with vue-router-sync. https://github.com/declandewet/vue-meta/issues/82

When using these two plugins with SSR, the server crashes with a "document is not defined" Exception.
This exception is thrown because the `destroyed` method is called when handing the page over from the server to the client.
By not calling the `refresh` method on the server side we can avoid this exception and save render-time by not calling a method that has no effect when executed on the server.