### PR TITLE
In some case, we do need a clean tag without any other redundancy attributes. 

### DIFF
--- a/src/server/generators/tagGenerator.js
+++ b/src/server/generators/tagGenerator.js
@@ -19,6 +19,7 @@ export default function _tagGenerator (options = {}) {
               // these attributes are treated as children on the tag
               case 'innerHTML':
               case 'cssText':
+              case 'once':
                 return attrsStr
 
               // these form the attribute list for this tag
@@ -35,10 +36,15 @@ export default function _tagGenerator (options = {}) {
           // these tag types will have content inserted
           const closed = ['noscript', 'script', 'style'].indexOf(type) === -1
 
+          // generate tag exactly without any other redundance attribute
+          const observeTag = tag.once
+            ? ''
+            : `${attribute}="true" `
+
           // the final string for this specific tag
           return closed
-            ? `${tagsStr}<${type} ${attribute}="true" ${attrs}/>`
-            : `${tagsStr}<${type} ${attribute}="true" ${attrs}>${content}</${type}>`
+            ? `${tagsStr}<${type} ${observeTag}${attrs}/>`
+            : `${tagsStr}<${type} ${observeTag}${attrs}>${content}</${type}>`
         }, '')
       }
     }


### PR DESCRIPTION
## The problem

the vue-meta add an attribute to observe it's change.
```
Vue.use(Meta, {
  attribute: 'data-vue-meta', // the attribute name vue-meta adds to the tags it observes
})
```
It work in most case, but not all. for example, when I verify a website in baidu.com, I have to add a tag in html's head
```
<meta name="baidu-site-verification" content="xxxxxxxx"/>
```
I add the code like this,
```
meta: [
  {name: 'baidu-site-verification', content: 'xxxxxxxx'}
]
```
Unfortunately, the code above will fail to verify, because it generate the html like this
```
<meta data-vue-meta="true" name="baidu-site-verification" content="xxxxxxxx"/>
```
the attribute `data-vue-meta` is **NOT** expect in this verification.


## The solution
The keyword `once` mean not to observe the tag's change, and not need to generate a redundancy attribute.

```
meta: [
  {name: 'baidu-site-verification', content: 'xxxxxxxx', once:true }
]
```
and it will generate the html tag as expect
```
<meta name="baidu-site-verification" content="xxxxxxxx"/>
```

Any other good idea?
