### PR TITLE
Improve automatic installation criteria

### DIFF
--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -10,7 +10,7 @@ import {
 } from './constants'
 
 // automatic install
-if (typeof window !== 'undefined' && typeof window.Vue != 'undefined') {
+if (typeof window !== 'undefined' && typeof window.Vue !== 'undefined') {
   Vue.use(VueMeta)
 }
 

--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -10,7 +10,7 @@ import {
 } from './constants'
 
 // automatic install
-if (typeof Vue !== 'undefined') {
+if (typeof window !== 'undefined' && typeof window.Vue != 'undefined') {
   Vue.use(VueMeta)
 }
 


### PR DESCRIPTION
In Vue ecosystem, autoinstall feature is dedicated for cases when libraries are being included from CDN, instead of being bundled with the app. But testing for `Vue` being globally available is not enough to correctly target these cases. It also triggers if `Vue` is made globally available e.g. with webpack's `ProvidePlugin`.

Proposed solution avoids this problem. It's also used by [vuex](https://github.com/vuejs/vuex/blob/7d611adcca86d0a34fca3074a96dd958bd94f733/src/store.js#L13) and [vue-router](https://github.com/vuejs/vue-router/blob/05a5f085fd7e230d4b51862f7a6086fec4378bc6/src/util/dom.js#L3).

