### PR TITLE
Clear Interval if the component doesn't have the $el property

### DIFF
--- a/src/shared/plugin.js
+++ b/src/shared/plugin.js
@@ -87,7 +87,7 @@ export default function VueMeta (Vue, options = {}) {
       if (this._hasMetaInfo) {
         // Wait that element is hidden before refreshing meta tags (to support animations)
         const interval = setInterval(() => {
-          if (this.$el.offsetParent !== null) return
+          if (this.$el && this.$el.offsetParent !== null) return
           clearInterval(interval)
           batchID = batchUpdate(batchID, () => this.$meta().refresh())
         }, 50)


### PR DESCRIPTION
Using the `vuelidate` plugin creates components that do not have an `$el` property, but still have `_hasMetaInfo` set to true, which results in the setInterval never being cleared. There may be other plugins that create similar components.

Changing the line to `if (this.$el && this.$el.offsetParent !== null) return` would resolve this issue.