### PR TITLE
Removed old Typescript snippet from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -813,18 +813,3 @@ If this were not the case, you would have to instruct Babel to convert `default`
 # Examples
 
 To run the examples; clone this repository & run `npm install` in the root directory, and then run `npm run dev`. Head to http://localhost:8080.
-
-# TypeScript Support
-
-If you have problems with types using vue-meta, then you're most probably using vue-class-component.
-In any troublesome situation, just add the following ambient declaration to your types:
-
-```js
-import { MetaInfo } from 'vue-meta';
-
-declare module "vue/types/vue" {
-  interface Vue {
-    metaInfo?: MetaInfo | (() => MetaInfo)
-  }
-}
-```


### PR DESCRIPTION
I started getting an error saying "All declarations of metaInfo must have identical modifiers" after updating to the stable version of vue-cli. After some investigation, it looks like the code in this snippet is causing conflicts with the typings that have since been added to the actual code. Removing the code snippet removed the error, and the type hints still work properly.

Hope this helps!