### PR TITLE
fixed issue #52

### DIFF
--- a/src/shared/getMetaInfo.js
+++ b/src/shared/getMetaInfo.js
@@ -100,7 +100,7 @@ export default function _getMetaInfo (options = {}) {
 
     // replace title with populated template
     if (info.titleTemplate) {
-      info.title = applyTemplate(component)(info.titleTemplate)(info.titleChunk)
+      info.title = applyTemplate(component)(info.titleTemplate)(info.titleChunk || '')
     }
 
     // convert base tag to an array so it can be handled the same way


### PR DESCRIPTION
fixed issue #52 

Still have issue #52 .
I found the reason, here's the code.
```
   // backup the title chunk in case user wants access to it
    if (info.title) {
      info.titleChunk = info.title;
    }

    // replace title with populated template
    if (info.titleTemplate) {
      info.title = applyTemplate(component)(info.titleTemplate)(info.titleChunk);
    }
    ...
    var applyTemplate = function (component) { return function (template) { return function (chunk) { return typeof template === 'function' ? template.call(component, chunk) : template.replace(/%s/g, chunk); }; }; };
```

![wx20180929-181139](https://user-images.githubusercontent.com/7577317/46244580-538d6c00-c413-11e8-8356-b1d12120fba7.png)

At line `514`, `info.title === ''` is `true`, so `info.titleChunk` is `undefined`, but `info.titleTemplate === '%s | MySite'` still  `true`, so when `template.replace(/%s/g, chunk)`, it will return `undefined  | MySite`.