### PR TITLE
fix(pkg): remove extra yarn.lock from npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,6 @@
   },
   "files": [
     "lib",
-    "yarn.lock",
     "types/index.d.ts",
     "types/vue.d.ts"
   ],


### PR DESCRIPTION
The `yarn.lock` file which is included in npm packages has `220K` overhead which is ignored by yarn according to the [docs](https://yarnpkg.com/lang/en/docs/yarn-lock/#toc-current-package-only)